### PR TITLE
Improve Build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.20)
+project(RPX-100)
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+find_library(websockets websockets)
+find_library(liquid liquid)
+find_library(lime LimeSuite)
+add_compile_options(-g)
+
+file(GLOB SRC_FILES RPX-100.cpp SDRsamples.cpp WebSocketServer.cpp Util.cpp sockets/*.cpp)
+add_executable(RPX-100 ${SRC_FILES})
+target_link_libraries(RPX-100 PRIVATE Threads::Threads ${websockets} ${liquid} ${lime})
+add_link_options(RPX-100 -lLimeSuite -lliquid -lwebsockets)

--- a/compile.sh
+++ b/compile.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+/usr/bin/g++ -g RPX-100.cpp -g SDRsamples.cpp -g WebSocketServer.cpp -g Util.cpp -g sockets/*.cpp -o RPX-100 -lLimeSuite -L/usr/lib -lpthread -L/usr/lib -lliquid -L/usr/lib -lwebsockets -L/usr/lib

--- a/compile.txt
+++ b/compile.txt
@@ -1,1 +1,0 @@
-/usr/bin/g++ -g /opt/build/RPX-100/RPX-100.cpp -g /opt/build/RPX-100/SDRsamples.cpp -g /opt/build/RPX-100/WebSocketServer.cpp -g /opt/build/RPX-100/Util.cpp -g /opt/build/RPX-100/sockets/*.cpp -o /opt/build/RPX-100/RPX-100 -lLimeSuite -L/usr/lib -lpthread -L/usr/lib -lliquid -L/usr/lib -lwebsockets -L/usr/lib


### PR DESCRIPTION
* using a standard build system (cmake)
* fix the existing build system to allow different project locations (remove fully qualified paths, rename file to SH (it is a shell script after all), add a shebang